### PR TITLE
Move article pefixer method to model

### DIFF
--- a/app/mailers/link_mailer.rb
+++ b/app/mailers/link_mailer.rb
@@ -5,8 +5,9 @@ class LinkMailer < ApplicationMailer
     @applicant  = request.researcher
     @send_to    = request.researcher_email
     @oz         = request.research_proposal
-    @pv         = request.patient_org
+    @pv         = request.patient_org_with_article
     @link_for_pv= sterrenlink.output_link
-    mail(to: @send_to, subject: "Re: Sterrenlink")
+
+    mail(to: @send_to, subject: "Re: Sterrenlink", bcc: ENV['EMAIL'])
   end
 end

--- a/app/models/link_request.rb
+++ b/app/models/link_request.rb
@@ -1,9 +1,21 @@
 class LinkRequest < ApplicationRecord
+
+  ORGS_WITH_DE= ['DON', 'VOKK', 'BOSK', 'AVN', 'Cliëntenraad Reade', 'Afasiecliëntengroep', 'F side'] # 'F side' for testing
+
   validates :researcher, :research_org, :research_proposal, :researcher_email,
             :patient_org, :fonds, :application_date, presence: true
 
   has_many :sterrenlinks, dependent: :destroy
   # actually: has_one ^
+
+  def patient_org_with_article
+    if patient_org.in?(ORGS_WITH_DE)
+      "de #{patient_org}"
+    else
+      patient_org
+    end
+  end
+
 end
 
 # == Schema Information

--- a/app/models/sterrenlink.rb
+++ b/app/models/sterrenlink.rb
@@ -1,7 +1,6 @@
 class Sterrenlink < ApplicationRecord
 
   TYPEFORM_UID= ENV['TYPEFORM_V1_2'] # second version; articles removed from questionnaire
-  ORGS_WITH_DE= ['DON', 'VOKK', 'BOSK', 'AVN', 'Cliëntenraad Reade', 'Afasiecliëntengroep', 'F side'] # 'F side' for testing
 
   belongs_to :link_request
 
@@ -20,11 +19,10 @@ class Sterrenlink < ApplicationRecord
     end
 
     def compose_url_for(linkrequest)
-      find_article_for(linkrequest.patient_org)
       uri = URI.parse('https://sterren.typeform.com/to/'+ TYPEFORM_UID)
       uri.query = URI.encode_www_form(
           "oz" => linkrequest.research_proposal,
-          "pv" => @article + linkrequest.patient_org,
+          "pv" => linkrequest.patient_org_with_article,
           "fns" => linkrequest.fonds
       )
       uri.to_s.gsub('+', '%20')
@@ -40,13 +38,6 @@ class Sterrenlink < ApplicationRecord
       request.save
     end
 
-    def find_article_for(patient_org)
-      if patient_org.in?(ORGS_WITH_DE)
-        @article = "de "
-      else
-        @article = ''
-      end
-    end
 end
 
 # == Schema Information

--- a/app/views/link_mailer/send_link.html.erb
+++ b/app/views/link_mailer/send_link.html.erb
@@ -5,17 +5,17 @@
 
 
 <p>Onderaan deze mail staat de Sterrenlink.
-  Die stuurt u door naar de <%= @pv %>.</p>
+  Die stuurt u door naar <%= @pv %>.</p>
 
 
-<p>De <%= @pv %> krijgt met de link toegang tot een online vragenlijst,
+<p>De link geeft <%= @pv %> toegang tot een online vragenlijst,
   waarmee de Sterrenscore automatisch wordt bepaald.</p>
 <p>U ontvangt een pdf met deze score; de pdf stuurt u mee naar het fonds, samen met uw aanvraag/onderzoeksvoorstel. Afspraken over de datum waarop u de Sterrenscore nodig heeft, maakt u direct met de patiëntenvereniging.
 </p>
 <p>Houd er alstublieft rekening mee dat het verwerken van de score tijd kost;
   maximaal 48 uur tussen het moment dat de patiëntenvereniging
   de score verstuurt, en dat u de pdf ontvangt.</p>
-<p>Hieronder vindt u ook een korte toelichting voor de <%= @pv %>, om mee te sturen met de Sterrenlink.</p>
+<p>Hieronder vindt u ook een korte toelichting voor <%= @pv %>.</p>
 
 
 <p>Als u nog vragen heeft over de gang van zaken rond de Sterrenlink
@@ -45,7 +45,7 @@
 
 <p><strong>*** Ga naar de <%= link_to 'Sterrenscore vragenlijst', @link_for_pv %>*** </strong></p>
 
-<p>Voor vragen over de vragenlijst of hulp bij het invullen kunt u mailen naar maudcharta@gmail.com. U kunt ook mailen om een afspraak te maken voor een telefonische toelichting.
+<p>Voor vragen over de vragenlijst of hulp bij het invullen kunt u mailen naar <%= message.from %>. U kunt ook mailen om een afspraak te maken voor een telefonische toelichting.
 
 <p>Met vriendelijke groet,</p>
 

--- a/app/views/link_mailer/send_link.text.erb
+++ b/app/views/link_mailer/send_link.text.erb
@@ -1,5 +1,5 @@
 
-* Deze email is geoptimaliseerd voor html. U leest de versie zonder html ***
+* Deze email is geoptimaliseerd voor html. U leest de versie zonder html *
 
 Beste Onderzoeker,
 
@@ -8,17 +8,18 @@ aangevraagd op www.sterrenscore.nl voor <%= @oz %>
 
 
 Onderaan deze mail staat de Sterrenlink.
-Die stuurt u door naar de <%= @pv %>.
+Die stuurt u door naar <%= @pv %>.
 
 
-De <%= @pv %> krijgt met de link toegang tot een online vragenlijst,
+Met de link krijgt <%= @pv %> toegang tot een online vragenlijst,
 waarmee de Sterrenscore automatisch wordt bepaald.
-U ontvangt een pdf met deze score; de pdf stuurt u mee naar het fonds, samen met uw aanvraag/onderzoeksvoorstel. Afspraken over de datum waarop u de Sterrenscore nodig heeft, maakt u direct met de patiëntenvereniging.
+U ontvangt een pdf met deze score; de pdf stuurt u mee naar het fonds, samen met uw aanvraag/onderzoeksvoorstel.
+Afspraken over de datum waarop u de Sterrenscore nodig heeft, maakt u direct met de patiëntenvereniging.
 Houd er alstublieft rekening mee dat het verwerken van de score tijd kost;
 maximaal 48 uur tussen het moment dat de patiëntenvereniging
 de score verstuurt, en dat u de pdf ontvangt.
 
-Hieronder vindt u ook een korte toelichting voor de <%= @pv %>, om mee te sturen met de Sterrenlink.
+Hieronder vindt u ook een korte toelichting voor <%= @pv %>.
 
 
 Als u nog vragen heeft over de gang van zaken rond de Sterrenlink
@@ -48,7 +49,7 @@ DEZE LINK brengt u DIRECT NAAR DE VRAGENLIJST:
 
 <%= @link_for_pv %>
 
-Voor vragen over de vragenlijst of hulp bij het invullen kunt u mailen naar maudcharta@gmail.com. U kunt ook mailen om een afspraak te maken voor een telefonische toelichting.
+Voor vragen over de vragenlijst of hulp bij het invullen kunt u mailen naar <%= message.from %>. U kunt ook mailen om een afspraak te maken voor een telefonische toelichting.
 
 Met vriendelijke groet,
 
@@ -60,4 +61,4 @@ www.sterrenscore.nl
 
 *****************
 
-***** Verstuurd door de vriendelijke Sterrenscore Robot *****
+* Verstuurd door de vriendelijke Sterrenscore Robot *


### PR DESCRIPTION
Closes #20
The name_with_article is needed not alone to compose the Sterrenlink, but also in the mailer. So, it is now an instance method in the LinkRequest model.

Closes #16  
Closes #17
For real now.