### PR TITLE
Mailer button

### DIFF
--- a/app/controllers/sterrenlinks_controller.rb
+++ b/app/controllers/sterrenlinks_controller.rb
@@ -1,6 +1,6 @@
 class SterrenlinksController < ApplicationController
 
-before_action :load_link_request, only: [:index, :show, :create]
+before_action :load_link_request
 
   def index
     @sterrenlinks = @link_request.sterrenlinks
@@ -28,10 +28,19 @@ before_action :load_link_request, only: [:index, :show, :create]
   def destroy
   end
 
+  def ready_to_send
+    # @link_request = LinkRequest.find(params[:link_request_id])
+    # @sterrenlink = @link_request.sterrenlinks.find(params[:id])
+    @sterrenlink = @link_request.sterrenlinks.last
+    @sterrenlink.process_email
+    redirect_to [@link_request, @sterrenlink]
+  end
+
+
   private
 
     def load_link_request
-      @link_request = LinkRequest.find(params[:link_request_id])
+      @link_request ||= LinkRequest.find(params[:link_request_id])
     end
 
     def sterrenlink_params

--- a/app/controllers/sterrenlinks_controller.rb
+++ b/app/controllers/sterrenlinks_controller.rb
@@ -29,8 +29,6 @@ before_action :load_link_request
   end
 
   def ready_to_send
-    # @link_request = LinkRequest.find(params[:link_request_id])
-    # @sterrenlink = @link_request.sterrenlinks.find(params[:id])
     @sterrenlink = @link_request.sterrenlinks.last
     @sterrenlink.process_email
     flash[:notice] = "Email is sent out!"

--- a/app/controllers/sterrenlinks_controller.rb
+++ b/app/controllers/sterrenlinks_controller.rb
@@ -33,9 +33,9 @@ before_action :load_link_request
     # @sterrenlink = @link_request.sterrenlinks.find(params[:id])
     @sterrenlink = @link_request.sterrenlinks.last
     @sterrenlink.process_email
+    flash[:notice] = "Email is sent out!"
     redirect_to [@link_request, @sterrenlink]
   end
-
 
   private
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
   default from: ENV['STERMAIL']
-  # layout 'link_mailer'
+  layout 'mailer'
 end

--- a/app/models/sterrenlink.rb
+++ b/app/models/sterrenlink.rb
@@ -5,7 +5,6 @@ class Sterrenlink < ApplicationRecord
   belongs_to :link_request
 
   before_save :compose_link
-  # after_create :process_email
 
   def process_email
     send_to_applicant

--- a/app/views/sterrenlinks/show.html.erb
+++ b/app/views/sterrenlinks/show.html.erb
@@ -3,8 +3,10 @@ SHOW me your sterrenlink
 <p><%= @sterrenlink.id %>: <%= @sterrenlink.output_link %></p>
 
 <%#= button_to "Send Sterrenlink", ready_to_send_link_request_sterrenlink_path([@sterrenlink.link_request, @sterrenlink]), class:'button'%>
-
-
+<blockquote><%= button_to "Send Sterrenlink", [:ready_to_send, @sterrenlink.link_request, @sterrenlink], class:'button'%> to <%= @link_request.researcher_email %>
+</blockquote>
 <p><%= link_to "Back to LinkRequest", @link_request %></p>
 
-<%= link_to "Send Sterrenlink now", [:ready_to_send, @sterrenlink.link_request, @sterrenlink], method: :post %>
+<%#= link_to "Send Sterrenlink now", [:ready_to_send, @sterrenlink.link_request, @sterrenlink], method: :post %>
+<!--Not working: -->
+<%#= link_to "Send Sterrenlink now", [:ready_to_send, @sterrenlink], method: :post %>

--- a/app/views/sterrenlinks/show.html.erb
+++ b/app/views/sterrenlinks/show.html.erb
@@ -2,7 +2,7 @@ SHOW me your sterrenlink
 
 <p><%= @sterrenlink.id %>: <%= @sterrenlink.output_link %></p>
 
-<%= button_to "Send Sterrenlink", ready_to_send_link_request_sterrenlink_path([@sterrenlink.link_request, @sterrenlink]), class:'button'%>
+<%#= button_to "Send Sterrenlink", ready_to_send_link_request_sterrenlink_path([@sterrenlink.link_request, @sterrenlink]), class:'button'%>
 
 
 <p><%= link_to "Back to LinkRequest", @link_request %></p>

--- a/app/views/sterrenlinks/show.html.erb
+++ b/app/views/sterrenlinks/show.html.erb
@@ -1,13 +1,21 @@
-SHOW me your sterrenlink
-<p id="notice"><%= notice %></p>
-
+<h2>Sterrenlink</h2>
 <p><%= @sterrenlink.id %>: <%= @sterrenlink.output_link %></p>
 
-<%#= button_to "Send Sterrenlink", ready_to_send_link_request_sterrenlink_path([@sterrenlink.link_request, @sterrenlink]), class:'button'%>
+<% unless @sterrenlink.link_request.sterrenlink_sent_at.blank? %>
+
 <blockquote><%= button_to "Send Sterrenlink", [:ready_to_send, @sterrenlink.link_request, @sterrenlink], class:'button'%> to <%= @link_request.researcher_email %>
+
+  <p id="notice"><%= notice %></p>
+
 </blockquote>
+<% end %>
+
 <p><%= link_to "Back to LinkRequest", @link_request %></p>
 
+
+<!--MEMO ignore comments, they are for reference only-->
+<!--These work as well:-->
 <%#= link_to "Send Sterrenlink now", [:ready_to_send, @sterrenlink.link_request, @sterrenlink], method: :post %>
-<!--Not working: -->
+<!--And these do not: -->
 <%#= link_to "Send Sterrenlink now", [:ready_to_send, @sterrenlink], method: :post %>
+<%#= button_to "Send Sterrenlink", ready_to_send_link_request_sterrenlink_path([@sterrenlink.link_request, @sterrenlink]), class:'button'%>

--- a/app/views/sterrenlinks/show.html.erb
+++ b/app/views/sterrenlinks/show.html.erb
@@ -1,3 +1,10 @@
 SHOW me your sterrenlink
 
 <p><%= @sterrenlink.id %>: <%= @sterrenlink.output_link %></p>
+
+<%= button_to "Send Sterrenlink", ready_to_send_link_request_sterrenlink_path([@sterrenlink.link_request, @sterrenlink]), class:'button'%>
+
+
+<p><%= link_to "Back to LinkRequest", @link_request %></p>
+
+<%= link_to "Send Sterrenlink now", [:ready_to_send, @sterrenlink.link_request, @sterrenlink], method: :post %>

--- a/app/views/sterrenlinks/show.html.erb
+++ b/app/views/sterrenlinks/show.html.erb
@@ -1,4 +1,5 @@
 SHOW me your sterrenlink
+<p id="notice"><%= notice %></p>
 
 <p><%= @sterrenlink.id %>: <%= @sterrenlink.output_link %></p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,11 @@ Rails.application.routes.draw do
 
   root to: 'link_requests#index'
   resources :link_requests do
-    resources :sterrenlinks
+    resources :sterrenlinks do
+      member do
+        post :ready_to_send
+      end
+    end
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
closes #24

In PR #25 , the mailer was disabled because it should not fire automatically.
This PR adds a button/link, that requires admin action to fire the mailer, whenever admin has finished editing the Sterrenlink or the LinkRequest.